### PR TITLE
Fix Intel ICX + CUDA host compiler incompatibilities in Kokkos

### DIFF
--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -224,6 +224,13 @@ if(KOKKOS_CXX_COMPILER_ID STREQUAL NVIDIA)
   unset(_UPPERCASE_CMAKE_BUILD_TYPE)
 endif()
 
+# Intel ICX (IntelLLVM) is not officially supported as an nvcc host compiler in CUDA 12+.
+# When nvcc_wrapper is used as a RULE_LAUNCH_COMPILE launcher with Intel ICX as host,
+# nvcc's host_config.h rejects it unless --allow-unsupported-compiler is passed.
+if(KOKKOS_CXX_COMPILER_ID STREQUAL NVIDIA AND KOKKOS_CXX_HOST_COMPILER_ID STREQUAL "IntelLLVM")
+  global_append(KOKKOS_CUDA_OPTIONS "--allow-unsupported-compiler")
+endif()
+
 #------------------------------- KOKKOS_HIP_OPTIONS ---------------------------
 kokkos_option(IMPL_AMDGPU_FLAGS "" STRING "Set compiler flags for AMD GPUs")
 kokkos_option(IMPL_AMDGPU_LINK "" STRING "Set linker flags for AMD GPUs")

--- a/core/src/impl/Kokkos_BitOps.hpp
+++ b/core/src/impl/Kokkos_BitOps.hpp
@@ -21,7 +21,12 @@
 #include <cstdint>
 #include <climits>
 
-#if defined(KOKKOS_COMPILER_INTEL) || defined(KOKKOS_COMPILER_INTEL_LLVM)
+// When compiling with nvcc, __CUDACC__ is defined by nvcc's own clang even
+// though Intel LLVM is the host compiler. Intel LLVM 2025.3+ headers included
+// via <immintrin.h> (e.g. AMX/AVX-10.2 intrinsics) use builtins that nvcc's
+// clang does not support, causing compilation failures. Guard against this.
+#if (defined(KOKKOS_COMPILER_INTEL) || defined(KOKKOS_COMPILER_INTEL_LLVM)) && \
+    !defined(__CUDACC__)
 #include <immintrin.h>
 #endif
 
@@ -55,7 +60,8 @@ inline int int_log2_device(unsigned i) {
 KOKKOS_IMPL_HOST_FUNCTION
 inline int int_log2_host(unsigned i) {
 // duplicating shift to avoid unused warning in else branch
-#if defined(KOKKOS_COMPILER_INTEL) || defined(KOKKOS_COMPILER_INTEL_LLVM)
+#if (defined(KOKKOS_COMPILER_INTEL) || defined(KOKKOS_COMPILER_INTEL_LLVM)) && \
+    !defined(__CUDACC__)
   constexpr int shift = sizeof(unsigned) * CHAR_BIT - 1;
   (void)shift;
   return _bit_scan_reverse(i);
@@ -115,7 +121,8 @@ inline int bit_first_zero_device(unsigned i) noexcept {
 KOKKOS_IMPL_HOST_FUNCTION
 inline int bit_first_zero_host(unsigned i) noexcept {
   constexpr unsigned full = ~0u;
-#if defined(KOKKOS_COMPILER_INTEL) || defined(KOKKOS_COMPILER_INTEL_LLVM)
+#if (defined(KOKKOS_COMPILER_INTEL) || defined(KOKKOS_COMPILER_INTEL_LLVM)) && \
+    !defined(__CUDACC__)
   return full != i ? _bit_scan_forward(~i) : -1;
 #elif defined(KOKKOS_COMPILER_CRAYC)
   return full != i ? _popcnt(i ^ (i + 1)) - 1 : -1;
@@ -161,7 +168,8 @@ KOKKOS_IMPL_DEVICE_FUNCTION inline int bit_scan_forward_device(unsigned i) {
 }
 
 KOKKOS_IMPL_HOST_FUNCTION inline int bit_scan_forward_host(unsigned i) {
-#if defined(KOKKOS_COMPILER_INTEL) || defined(KOKKOS_COMPILER_INTEL_LLVM)
+#if (defined(KOKKOS_COMPILER_INTEL) || defined(KOKKOS_COMPILER_INTEL_LLVM)) && \
+    !defined(__CUDACC__)
   return _bit_scan_forward(i);
 #elif defined(KOKKOS_COMPILER_CRAYC)
   return i ? _popcnt(~i & (i - 1)) : -1;
@@ -208,7 +216,8 @@ KOKKOS_IMPL_DEVICE_FUNCTION inline int bit_count_device(unsigned i) {
 }
 
 KOKKOS_IMPL_HOST_FUNCTION inline int bit_count_host(unsigned i) {
-#if defined(KOKKOS_COMPILER_INTEL) || defined(KOKKOS_COMPILER_INTEL_LLVM)
+#if (defined(KOKKOS_COMPILER_INTEL) || defined(KOKKOS_COMPILER_INTEL_LLVM)) && \
+    !defined(__CUDACC__)
   return _popcnt32(i);
 #elif defined(KOKKOS_COMPILER_CRAYC)
   return _popcnt(i);


### PR DESCRIPTION
Enable building with Intel ICX (IntelLLVM) as the nvcc host compiler,
which is required to support Intel GPU + NVIDIA GPU mixed environments
(e.g., EKAT on Perlmutter GPU nodes with Intel oneAPI toolchain).
(ie `intelgpu` on pm-gpu)

### `cmake/kokkos_arch.cmake`
When `KOKKOS_CXX_COMPILER_ID` is `NVIDIA` and the host compiler is
`IntelLLVM`, automatically append `--allow-unsupported-compiler` to
`KOKKOS_CUDA_OPTIONS`. CUDA 12+ officially rejects Intel ICX as an
nvcc host compiler; this flag bypasses that check.

### `core/src/impl/Kokkos_BitOps.hpp`
Guard all `#include <immintrin.h>` and Intel intrinsic usages
(`_bit_scan_reverse`, `_bit_scan_forward`, `_popcnt32`) with
`!defined(__CUDACC__)`. When nvcc compiles device translation units,
it uses its own internal clang frontend â Intel LLVM 2025.3+ AMX/AVX
headers introduce builtins that nvcc's clang does not support,
causing compilation failures.

This is needed for E3SM/EKAT to support heterogeneous HPC nodes
(e.g., Aurora, or Perlmutter with Intel oneAPI) where Intel ICX is
the primary compiler but CUDA is also present.

